### PR TITLE
Verify registry digests instead of local image IDs in cron tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,13 +98,14 @@ jobs:
             quay.io/akhilerm/linux-utils:${{ env.TAG }}
 
       - name: Verify docker.io to quay.io
-        # pull both images and check if hash is same
+        # The copy must be byte-identical, so the registry manifest digests
+        # have to match. (Local `docker images -q` IDs are unreliable for
+        # multi-arch images, so compare the registry digests directly.)
         run: |
-          docker pull docker.io/openebs/linux-utils:ci
-          docker pull quay.io/akhilerm/linux-utils:${{ env.TAG }}
-          HASH1=$(docker images -q docker.io/openebs/linux-utils:ci)
-          HASH2=$(docker images -q quay.io/akhilerm/linux-utils:${{ env.TAG }})
-          test "$HASH1" = "$HASH2"
+          SRC=$(docker buildx imagetools inspect docker.io/openebs/linux-utils:ci --format '{{.Manifest.Digest}}')
+          DST=$(docker buildx imagetools inspect quay.io/akhilerm/linux-utils:${{ env.TAG }} --format '{{.Manifest.Digest}}')
+          echo "pushed digest: ${DST} (expected ${SRC})"
+          test "$SRC" = "$DST"
 
       # Second direction: quay.io -> docker.io
       - name: Copy quay.io to docker.io
@@ -115,13 +116,14 @@ jobs:
             docker.io/akhilerm/centos-test:stream9
 
       - name: Verify quay.io to docker.io
-        # pull both images and check if hash is same
+        # The copy must be byte-identical, so the registry manifest digests
+        # have to match. (Local `docker images -q` IDs are unreliable for
+        # multi-arch images, so compare the registry digests directly.)
         run: |
-          docker pull quay.io/centos/centos:stream9-minimal
-          docker pull docker.io/akhilerm/centos-test:stream9
-          HASH1=$(docker images -q quay.io/centos/centos:stream9-minimal)
-          HASH2=$(docker images -q docker.io/akhilerm/centos-test:stream9)
-          test "$HASH1" = "$HASH2"
+          SRC=$(docker buildx imagetools inspect quay.io/centos/centos:stream9-minimal --format '{{.Manifest.Digest}}')
+          DST=$(docker buildx imagetools inspect docker.io/akhilerm/centos-test:stream9 --format '{{.Manifest.Digest}}')
+          echo "pushed digest: ${DST} (expected ${SRC})"
+          test "$SRC" = "$DST"
 
   test3:
     name: Unit Test


### PR DESCRIPTION
## Problem

The scheduled `docker.io ↔ quay.io` copy test ([run 27261683023](https://github.com/akhilerm/tag-push-action/actions/runs/27261683023)) failed at the **Verify** step even though the **copy succeeded** — the logs show source and destination resolving to the identical manifest digest `sha256:8cfc5b7d82ce…85483`.

The verify steps compared **local image IDs** (`docker images -q`), which are unreliable for **multi-arch** images on the containerd image store now used by `ubuntu-24.04` runners. The push job didn't hit this because it tests single-arch `busybox`; only the cron job uses multi-arch images (`openebs/linux-utils`, `centos:stream9-minimal`).

This was effectively the first real scheduled run after the cron schedule was fixed in #387, so the latent flaw only just surfaced.

## Fix

Both verify steps (both copy directions) now compare the **registry manifest digests** directly via `docker buildx imagetools inspect ... --format '{{.Manifest.Digest}}'`. Buildx is preinstalled on GitHub-hosted runners, and `imagetools inspect` reads the digest straight from the registry (no `docker pull` needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)